### PR TITLE
Create extensions.yml file

### DIFF
--- a/meta/extensions
+++ b/meta/extensions
@@ -1,0 +1,5 @@
+extensions:
+  - args:
+      ext_dir: eda/plugins/event_filter
+  - args:
+      ext_dir: eda/plugins/event_source


### PR DESCRIPTION
Adding the `meta/extensions.yml` file, which is required to display EDA content in documentation on Automation Hub. This file points to the EDA plugin paths inside the collection. Eventually, `ansible-doc` will use this file to display EDA plugins and list their full contents on Automation Hub, exactly like other Ansible plugins. This feature is in development. Currently, galaxy-importer directly consumes this file to display EDA plugins in Automation Hub. 