### PR TITLE
CA-8433 Added .gitignore and .gitattributes, sync tox.ini

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.py                            text eol=lf
+*.md                            text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# python
+*.pyc
+# venv
+venv
+# tests
+tests/output
+.pytest_cache/
+# Ide's
+.vscode
+.idea
+
+# Builds
+*.tar.gz
+*egg-info
+.tox
+releases/*

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-## Dynatrace + Red Hat Event Driven Ansible : Auto-Remediation
+# Dynatrace + Red Hat Event Driven Ansible: Auto-Remediation
 
 This Event source plugin from Dynatrace captures all problems from your Dynatrace tenant and in conjunction with Ansible EDA rulebooks helps to enable auto-remediation in your environment.
 
-## Requirements:
+## Requirements
+
 * Dynatrace SaaS or Managed environment
 * Dynatrace API Token with the following scopes: `Read problems` and `Write problems`
 * Ansible Automation Platform with EDA Controller instance
 
-# Example rulebook
+## Example rulebook
+
 ```yaml
 ---
 - name: Listen for events on a webhook
@@ -69,7 +71,7 @@ Apache header:
 
 ## Additional Questions/Remarks
 
-If you do have additional questions/remarks, feel free to reach out to Dynatrace support(support@dynatrace.com), either via slack or email.
+If you do have additional questions/remarks, feel free to reach out to Dynatrace support (support@dynatrace.com), either via Slack or email.
 
 If you think this template did not solve all your problems, please also let us know, either with a message or a pull request.
 Together we can improve this template to make it easier for our future projects.

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,28 @@
-# This file can be used locally and in a Github Workflow to run `tox` and thereby run the below linters on your EDA content
-
+# from https://github.com/ansible/eda-partner-testing/blob/main/tox.ini
 [tox]
-envlist = ruff, darglint, pylint-event-source
+envlist = ruff, darglint, pylint
+skipsdist = true
 requires = 
     ruff
     darglint
     pylint
 
+[testenv]
+allowlist_externals=*
+commands =
+    {envpython} --version
+
 [testenv:ruff]
 deps = ruff
-commands = ruff check --select ALL --ignore INP001 -q /extensions/eda/plugins
-
+commands =
+    bash -c 'ruff check --exclude .tox --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100 -q extensions/eda/plugins'
 
 [testenv:darglint]
 deps = darglint
-commands = darglint -s numpy -z full /extensions/eda/plugins
+commands =
+    bash -c 'darglint -s numpy -z full extensions/eda/plugins'
 
-
-# if pylint warns about missing __init__.py files in directories, there's no need to include them if you ensure that the paths in the below pylint `commands` point directly to the *.py files under the event_source/ dir, as shown in the template path here
-[testenv:pylint-event-source]
+[testenv:pylint]
 deps = pylint
-commands = pylint /extensions/eda/plugins/event_source/*.py --output-format=parseable -sn --disable R0801
+commands = 
+    bash -c 'find ./extensions/eda/plugins -name "*.py" -print0 | xargs -0 pylint --output-format=parseable -sn --disable R0801,E0401,C0103,R0913'


### PR DESCRIPTION
* Added .gitignore from https://github.com/ansible/eda-partner-testing/blob/main/.gitignore
* Added .gitattribute such that cloning this repo on Linux and Windows leads to normal `\n`
* Also fixed some (simple) markdown linter errors in README
* Synced tox.ini from https://github.com/ansible/eda-partner-testing/blob/main/tox.ini 

