### PR TITLE
CA-9156: raise minimum Ansible version

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.14.0'


### PR DESCRIPTION
Raises the minimum version requirement for Ansible declared in the meta folder.

This is required for the certification and publishing process. 