### PR TITLE
CA-9156: add schedules for nightly runs of ci actions

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -4,7 +4,9 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-
+  # Run ansible-lint nightly
+  schedule:
+    - cron: '0 2 * * *'
 jobs:
   build:
     name: Ansible Lint # Naming the build is important to use it as a status check

--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -4,7 +4,9 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-
+  # Run ansible-test nightly
+  schedule:
+    - cron: '0 2 * * *'
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,6 +1,13 @@
 ---
-on: [push, pull_request]
 name: Tox
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # Run tox nightly
+  schedule:
+    - cron: '0 2 * * *'
 jobs:
   tox:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tests/output
 releases/*
 vars.yml
 *__pycac
+.ruff_cache
 
 # Antsibull-changelog
 changelogs/.plugin-cache.yaml


### PR DESCRIPTION
This PR contains: 

* add schedule to run CI actions like `ansible-lint`, `ansible-test` and `tox` nightly