### PR TITLE
fix: bump requires_ansible version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 **Topics**
 
+- <a href="#v1-2-1">v1\.2\.1</a>
+    - <a href="#minor-changes">Minor Changes</a>
 - <a href="#v1-2-0">v1\.2\.0</a>
     - <a href="#release-summary">Release Summary</a>
-    - <a href="#minor-changes">Minor Changes</a>
+    - <a href="#minor-changes-1">Minor Changes</a>
+
+<a id="v1-2-1"></a>
+## v1\.2\.1
+
+<a id="minor-changes"></a>
+### Minor Changes
+
+* ansible\-lint \- update requires\_ansible to \>\=2\.15\.0 to fix ansible\-lint action
 
 <a id="v1-2-0"></a>
 ## v1\.2\.0
@@ -14,7 +24,7 @@
 
 Initial release of the even source plugin dt\_webhook\.
 
-<a id="minor-changes"></a>
+<a id="minor-changes-1"></a>
 ### Minor Changes
 
 * Set up ansible\-lint and ansible\-test for collection\.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -3,8 +3,15 @@ releases:
   1.2.0:
     changes:
       minor_changes:
-        - Set up ansible-lint and ansible-test for collection.
+      - Set up ansible-lint and ansible-test for collection.
       release_summary: Initial release of the even source plugin dt_webhook.
     fragments:
-      - CA-9156-add-ansible-lint-and-ansible-test.yml
+    - CA-9156-add-ansible-lint-and-ansible-test.yml
     release_date: '2024-04-24'
+  1.2.1:
+    changes:
+      minor_changes:
+      - ansible-lint - update requires_ansible to >=2.15.0 to fix ansible-lint action
+    fragments:
+    - 38-update-requires_ansible.yml
+    release_date: '2024-08-05'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -3,15 +3,15 @@ releases:
   1.2.0:
     changes:
       minor_changes:
-      - Set up ansible-lint and ansible-test for collection.
+        - Set up ansible-lint and ansible-test for collection.
       release_summary: Initial release of the even source plugin dt_webhook.
     fragments:
-    - CA-9156-add-ansible-lint-and-ansible-test.yml
+      - CA-9156-add-ansible-lint-and-ansible-test.yml
     release_date: '2024-04-24'
   1.2.1:
     changes:
       minor_changes:
-      - ansible-lint - update requires_ansible to >=2.15.0 to fix ansible-lint action
+        - ansible-lint - update requires_ansible to >=2.15.0 to fix ansible-lint action
     fragments:
-    - 38-update-requires_ansible.yml
+      - 38-update-requires_ansible.yml
     release_date: '2024-08-05'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: dynatrace
 name: event_driven_ansible
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.0
+version: 1.2.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy
-requires_ansible: '>=2.14.0'
+requires_ansible: '>=2.15.0'


### PR DESCRIPTION

This PR updates the `requires_ansible` value to the ansible_core version `>=2.15.0`. This fixes the `ansible-lint`[ GitHub action.](https://github.com/Dynatrace/Dynatrace-EventDrivenAnsible/actions/runs/9823855329)

* [Ansible Core Version Matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix)
