### PR TITLE
chore: fix example section of dt_webhook in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,26 @@
 
 **Topics**
 
-- <a href="#v1-2-1">v1\.2\.1</a>
+- <a href="#v1-2-2">v1\.2\.2</a>
     - <a href="#minor-changes">Minor Changes</a>
+- <a href="#v1-2-1">v1\.2\.1</a>
+    - <a href="#minor-changes-1">Minor Changes</a>
 - <a href="#v1-2-0">v1\.2\.0</a>
     - <a href="#release-summary">Release Summary</a>
-    - <a href="#minor-changes-1">Minor Changes</a>
+    - <a href="#minor-changes-2">Minor Changes</a>
+
+<a id="v1-2-2"></a>
+## v1\.2\.2
+
+<a id="minor-changes"></a>
+### Minor Changes
+
+* README \- fix dt\_webhook rulebook example
 
 <a id="v1-2-1"></a>
 ## v1\.2\.1
 
-<a id="minor-changes"></a>
+<a id="minor-changes-1"></a>
 ### Minor Changes
 
 * ansible\-lint \- update requires\_ansible to \>\=2\.15\.0 to fix ansible\-lint action
@@ -24,7 +34,7 @@
 
 Initial release of the even source plugin dt\_webhook\.
 
-<a id="minor-changes-1"></a>
+<a id="minor-changes-2"></a>
 ### Minor Changes
 
 * Set up ansible\-lint and ansible\-test for collection\.

--- a/README.md
+++ b/README.md
@@ -56,24 +56,24 @@ The dt_webhook event-source plugin is capable of receiving events from Dynatrace
 
 ### Example rulebook
 
-  ```yaml
-  ---
-  - name: Listen for events on dt_webhook
-    hosts: all
-    sources:
-      - dynatrace.event_driven_ansible.dt_webhook:
-          host: 0.0.0.0
-          port: 5000
-          token: '{{ <token_variable_name> }}'
+```yaml
+---
+- name: Listen for events on dt_webhook
+  hosts: all
+  sources:
+    - dynatrace.event_driven_ansible.dt_webhook:
+        host: 0.0.0.0
+        port: 5000
+        token: '{{ <token_variable_name> }}'
 
-    rules:
-      - name: API Endpoint not available
-        condition: event.payload.eventData["event.name"] is match ("Monitoring not available")
-        action:
-          run_job_template:
-            name: "Trigger test playbook"
-            organization: "Default"    
-  ```
+  rules:
+    - name: API Endpoint not available
+      condition: event.payload.eventData["event.name"] is match ("Monitoring not available")
+      action:
+        run_job_template:
+          name: "Trigger test playbook"
+          organization: "Default"    
+```
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This Event source plugin from Dynatrace captures all problems from your Dynatrac
 
 ## dt_webhook 
 
-The dt_webhook event-source plugin is capable of receiving events from Dynatrace via the "Send event to Event-Driven Ansible" workflow action of the [Red Hat Ansible for Workflows integration](https://docs.dynatrace.com/docs/platform-modules/automations/workflows/actions/redhat).
+The dt_webhook event-source plugin is capable of receiving events from Dynatrace via the "Send event to Event-Driven Ansible" workflow action of the [Red Hat Ansible for Workflows integration](https://docs.dynatrace.com/docs/platform-modules/automations/workflows/actions/red-hat/redhat-even-driven-ansible).
 
 ### Example rulebook
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -15,3 +15,10 @@ releases:
     fragments:
       - 38-update-requires_ansible.yml
     release_date: '2024-08-05'
+  1.2.2:
+    changes:
+      minor_changes:
+        - README - fix dt_webhook rulebook example
+    fragments:
+      - 39-fix-readme.yml
+    release_date: '2024-09-17'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: dynatrace
 name: event_driven_ansible
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.1
+version: 1.2.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
- fix the preview of the README in the [Automation Hub](https://console.redhat.com/ansible/automation-hub/repo/published/dynatrace/event_driven_ansible/docs/) and update link to docs
- bump version to `1.2.2`